### PR TITLE
Queued EKEventStoreChangedNotification notifications by using a timer to avoid crashes when events are deleted.

### DIFF
--- a/MWM/MWMNotificationsManager.m
+++ b/MWM/MWMNotificationsManager.m
@@ -35,13 +35,15 @@
 
 @property (nonatomic, strong) NSTimer *notifCalendarTimer;
 
+@property (nonatomic, strong) NSTimer *storeChangedTimer;
+
 @property (nonatomic, strong) EKEventStore *eventStore;
 
 @end
 
 @implementation MWMNotificationsManager
 
-@synthesize notifCalendarTimer, eventStore;
+@synthesize notifCalendarTimer, storeChangedTimer, eventStore;
 
 static MWMNotificationsManager *sharedManager;
 
@@ -64,16 +66,21 @@ static MWMNotificationsManager *sharedManager;
     if (enable) {
         [[NSNotificationCenter defaultCenter] removeObserver:self name:EKEventStoreChangedNotification object:eventStore];
         self.eventStore= [[EKEventStore alloc] init];
-        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(storeChanged:)
+        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(storeChangedHandler)
                                                      name:EKEventStoreChangedNotification object:eventStore];
         [[NSNotificationCenter defaultCenter] removeObserver:self name:EKEventStoreChangedNotification object:nil];
-        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(storeChanged)
+        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(storeChangedHandler)
                                                      name:EKEventStoreChangedNotification object:nil];
         
         [self storeChanged];
     } else {
         [[NSNotificationCenter defaultCenter] removeObserver:self name:EKEventStoreChangedNotification object:nil];
     }
+}
+
+- (void) storeChangedHandler {
+    [storeChangedTimer invalidate];
+    storeChangedTimer = [NSTimer scheduledTimerWithTimeInterval:1 target:self selector:@selector(storeChanged) userInfo:nil repeats:NO];
 }
 
 - (void) storeChanged {

--- a/MWM/WidgetCalendar.m
+++ b/MWM/WidgetCalendar.m
@@ -94,7 +94,9 @@ static CGFloat widgetHeight = 32;
 
 - (void) storeChanged {
     NSLog(@"Calendar Changes Detected");
-    [self update:-1];
+    //[self update:-1];
+    [internalUpdateTimer invalidate];
+    internalUpdateTimer = [NSTimer scheduledTimerWithTimeInterval:1 target:self selector:@selector(internalUpdate:) userInfo:nil repeats:NO];
 }
 
 - (void) timeChanged {


### PR DESCRIPTION
Issue: Deleting the next event (in my case an iCloud calendar synced from my Mac) would cause the MWM app to crash almost every time.

Possible Cause: The event deletion causes several EKEventStoreChangedNotification notifications to fire rapidly, and while handling the first notification the event may still be changing, leading to the crash. That is my theory.

Resolution: Using a timer to delay handling the notification, effectively queuing multiple repeated notifications, eliminated the crashes in my testing. This will also reduce the amount of processing to handle event changes.
